### PR TITLE
환경변수와 관련되지 않는 builtin함수 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ minishell
 *.a
 *.tmp
 *.out
+test.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yooh <yooh@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: dongglee <dongglee@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/24 08:15:46 by yooh              #+#    #+#             */
-/*   Updated: 2022/12/29 08:31:20 by yooh             ###   ########.fr       */
+/*   Updated: 2022/12/29 16:50:44 by dongglee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,5 +102,12 @@ char		**parse_readline(char *input);
 
 // signal.c
 void		setsignal(void);
+void		setsignal_ignored(void);
+
+//builtin_1.c
+int			builtin_echo(char **cmd);
+int			builtin_pwd(char **cmd);
+int			builtin_exit(char **cmd);
+int			builtin_cd(char **cmd);
 
 #endif

--- a/srcs/builtin_1.c
+++ b/srcs/builtin_1.c
@@ -1,0 +1,100 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_1.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dongglee <dongglee@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/12/28 15:50:37 by dongglee          #+#    #+#             */
+/*   Updated: 2022/12/29 16:50:35 by dongglee         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+// TODO: remove before submitting.
+#define FOR_BUILTIN_CHECK "run in builtin\n"
+
+// TODO: Implemente functions related to environment variables
+
+int	builtin_echo(char **cmd)
+{
+	int		flag_newline;
+	int		i;
+
+	printf(FOR_BUILTIN_CHECK);
+	i = 1;
+	flag_newline = TRUE;
+	if (ft_strncmp(cmd[i], "-n", 3) == 0)
+	{
+		++i;
+		flag_newline = FALSE;
+	}
+	while (cmd[i])
+	{
+		printf("%s", cmd[i++]);
+		if (cmd[i])
+			printf(" ");
+		else
+			break ;
+	}
+	if (flag_newline)
+		printf("\n");
+	return (0);
+}
+
+int	builtin_pwd(char **cmd)
+{
+	char		*path;
+	const int	size = 2046;
+
+	printf(FOR_BUILTIN_CHECK);
+	if (cmd[1])
+	{
+		perror("pwd: too many arguments\n");
+		return (1);
+	}
+	path = malloc(sizeof(char) * size);
+	getcwd(path, size);
+	printf("%s\n", path);
+	free(path);
+	return (0);
+}
+
+int	builtin_exit(char **cmd)
+{
+	int	i;
+
+	printf(FOR_BUILTIN_CHECK);
+	if (cmd[1])
+	{
+		if (cmd[2] != NULL)
+		{
+			perror("exit: too many arguments\n");
+			return (1);
+		}
+		i = 0;
+		if (cmd[1][i] == '-')
+			++i;
+		while (cmd[1][i])
+		{
+			if (!ft_isdigit(cmd[1][i++]))
+			{
+				perror("exit: numeric argument required\n");
+				return (255);
+			}
+		}
+		return (((unsigned)ft_atoi(cmd[1])) % 256);
+	}
+	return (0);
+}
+
+int	builtin_cd(char **cmd)
+{
+	if (!cmd[1])
+		return (0);
+	if (chdir(cmd[1]) == 0)
+		return (0);
+	perror("cd: Noa a directory\n");
+	return (1);
+}

--- a/srcs/builtin_1.c
+++ b/srcs/builtin_1.c
@@ -6,7 +6,7 @@
 /*   By: dongglee <dongglee@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/28 15:50:37 by dongglee          #+#    #+#             */
-/*   Updated: 2022/12/29 16:50:35 by dongglee         ###   ########.fr       */
+/*   Updated: 2022/12/29 16:55:41 by dongglee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,6 +95,6 @@ int	builtin_cd(char **cmd)
 		return (0);
 	if (chdir(cmd[1]) == 0)
 		return (0);
-	perror("cd: Noa a directory\n");
+	perror("cd: No such file or directory\n");
 	return (1);
 }

--- a/srcs/signal.c
+++ b/srcs/signal.c
@@ -6,7 +6,7 @@
 /*   By: dongglee <dongglee@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/28 14:44:36 by dongglee          #+#    #+#             */
-/*   Updated: 2022/12/28 14:44:39 by dongglee         ###   ########.fr       */
+/*   Updated: 2022/12/29 16:30:25 by dongglee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,10 +21,17 @@ void	handler(int signum)
 		rl_replace_line("", 0);
 		rl_redisplay();
 	}
+	printf("signum: %d\n", signum);
 }
 
 void	setsignal(void)
 {
 	signal(SIGINT, handler);
+	signal(SIGQUIT, SIG_IGN);
+}
+
+void	setsignal_ignored(void)
+{
+	signal(SIGINT, SIG_IGN);
 	signal(SIGQUIT, SIG_IGN);
 }


### PR DESCRIPTION
환경변수 관련된 부분은 환경변수 처리 방법을 정하는 것이 필요합니다.
환경변수 외 다른 다양한 함수에서 필요로 하는 변수가 있을 것을 대비하여 관련된 구조체를 만들어 관리하는 것이 좋아보입니다.
해당 구조체를 관리하는 방법으로는 아래 2가지를 생각해 보았습니다.

1. 전역변수 선언 (가능하면 전역변수는 사용하지 않는 것이 좋아보이긴 합니다.)
2. minishell만을 위한 모든 함수의 첫번째 인자에 해당 구조체를 전달. (개인적으로는 이 방법이 적절해 보입니다.)

참고: 
1. cd에서 `-`를 사용하는 기능은 Mandatory가 요구하는 사안을 넘어선다고 생각하여 구현하지 않았습니다. (OLDPWD역시 구현하지 않았습니다.)